### PR TITLE
Remove profile photo toggle button

### DIFF
--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -17,18 +17,62 @@ layout: default
   <article>
     {% if page.profile %}
       <div class="profile float-{% if page.profile.align == 'left' %}left{% else %}right{% endif %}">
-        {% if page.profile.image %}
+        {% assign profile_images = page.profile.images %}
+        {% assign profile_images_count = profile_images | size %}
+        {% if page.profile.image_circular %}
+          {% assign profile_image_class = 'img-fluid z-depth-1 rounded-circle' %}
+        {% else %}
+          {% assign profile_image_class = 'img-fluid z-depth-1 rounded' %}
+        {% endif %}
+        {% capture sizes %}(min-width: {{ site.max_width }}) {{ site.max_width | minus: 30 | times: 0.3 }}px, (min-width: 576px) 30vw, 95vw{% endcapture %}
+        {% if profile_images_count > 0 %}
+          <div class="profile-toggle" data-profile-toggle>
+            <div class="profile-toggle__images">
+              {% for profile_image_entry in profile_images %}
+                {% if profile_image_entry.path %}
+                  {% assign profile_image_file = profile_image_entry.path %}
+                {% else %}
+                  {% assign profile_image_file = profile_image_entry %}
+                {% endif %}
+                {% assign profile_image_alt = profile_image_entry.alt | default: page.profile.image_alt | default: profile_image_file %}
+                {% assign profile_image_path = profile_image_file | prepend: 'assets/img/' %}
+                <div
+                  class="profile-toggle__image{% if forloop.first %} profile-toggle__image--active{% endif %}"
+                  data-profile-image
+                  data-profile-image-index="{{ forloop.index0 }}"
+                  tabindex="0"
+                  role="button"
+                  aria-pressed="{% if forloop.first %}true{% else %}false{% endif %}"
+                  aria-label="{{ page.profile.toggle_aria_label | default: 'Profile photo' }} {{ forloop.index }} of {{ profile_images_count }}"
+                >
+                  {%
+                    include figure.liquid
+                    loading="eager"
+                    path=profile_image_path
+                    class=profile_image_class
+                    sizes=sizes
+                    alt=profile_image_alt
+                    cache_bust=true
+                  %}
+                </div>
+              {% endfor %}
+            </div>
+            {% if profile_images_count > 1 %}
+              <span class="sr-only" data-profile-toggle-status aria-live="polite">
+                Showing photo 1 of {{ profile_images_count }}
+              </span>
+            {% endif %}
+          </div>
+        {% elsif page.profile.image %}
           {% assign profile_image_path = page.profile.image | prepend: 'assets/img/' %}
-          {% if page.profile.image_circular %}
-            {% assign profile_image_class = 'img-fluid z-depth-1 rounded-circle' %}
-          {% else %}
-            {% assign profile_image_class = 'img-fluid z-depth-1
-      rounded' %}
-          {% endif %}
-          {% capture sizes %}(min-width: {{ site.max_width }}) {{ site.max_width | minus: 30 | times: 0.3}}px, (min-width: 576px)
-      30vw, 95vw"{% endcapture %}
+          {% assign profile_image_alt = page.profile.image_alt | default: page.profile.image %}
           {%
-            include figure.liquid loading="eager" path=profile_image_path class=profile_image_class sizes=sizes alt=page.profile.image
+            include figure.liquid
+            loading="eager"
+            path=profile_image_path
+            class=profile_image_class
+            sizes=sizes
+            alt=profile_image_alt
             cache_bust=true
           %}
         {% endif %}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -6,7 +6,12 @@ subtitle: <a href='#'>Affiliations</a>. Address. Contacts. Motto. Etc.
 
 profile:
   align: right
-  image: 1.jpg
+  images:
+    - path: 1.jpg
+      alt: Formal headshot in the office
+    - path: 2.jpg
+      alt: Casual outdoor portrait
+  image: 1.jpg # fallback for layouts that expect a single image
   image_circular: false # crops the image to make it circular
   more_info: >
     <p>555 your office number</p>
@@ -27,7 +32,7 @@ latest_posts:
   limit: 3 # leave blank to include all the blog posts
 ---
 
-Write your biography here. Tell the world about yourself. Link to your favorite [subreddit](http://reddit.com). You can put a picture in, too. The code is already in, just name your picture `prof_pic.jpg` and put it in the `img/` folder.
+Write your biography here. Tell the world about yourself. Link to your favorite [subreddit](http://reddit.com). You can put pictures in, too. Add them to the `assets/img/` folder and list them under `profile.images` in this page's front matter to enable the built-in photo switcher (click the picture to cycle through them, or keep using `profile.image` for a single photo).
 
 Put your address / P.O. box / other info right below your picture. You can also disable any of these elements by editing `profile` property of the YAML header of your `_pages/about.md`. Edit `_bibliography/papers.bib` and Jekyll will render your [publications page](/al-folio/publications/) automatically.
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -38,6 +38,29 @@ body.sticky-bottom-footer {
   }
 }
 
+.profile-toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  &__images {
+    position: relative;
+  }
+
+  &__image {
+    display: none;
+    cursor: pointer;
+
+    figure {
+      margin: 0;
+    }
+  }
+
+  &__image--active {
+    display: block;
+  }
+}
+
 // TODO: redefine content layout.
 
 /******************************************************************************

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -52,6 +52,65 @@ $(document).ready(function () {
     }
   });
 
+  document.querySelectorAll("[data-profile-toggle]").forEach(function (toggleEl) {
+    var imageWrappers = toggleEl.querySelectorAll("[data-profile-image]");
+    if (imageWrappers.length <= 1) {
+      return;
+    }
+
+    var activeIndex = 0;
+
+    imageWrappers.forEach(function (wrapper, index) {
+      if (wrapper.classList.contains("profile-toggle__image--active")) {
+        activeIndex = index;
+      }
+    });
+
+    var statusEl = toggleEl.querySelector("[data-profile-toggle-status]");
+
+    var setActiveImage = function (newIndex) {
+      var current = imageWrappers[activeIndex];
+      var next = imageWrappers[newIndex];
+
+      if (current) {
+        current.classList.remove("profile-toggle__image--active");
+        current.setAttribute("aria-pressed", "false");
+      }
+
+      if (next) {
+        next.classList.add("profile-toggle__image--active");
+        next.setAttribute("aria-pressed", "true");
+      }
+
+      activeIndex = newIndex;
+
+      if (statusEl) {
+        statusEl.textContent = "Showing photo " + (newIndex + 1) + " of " + imageWrappers.length;
+      }
+    };
+
+    var showNextImage = function () {
+      var nextIndex = (activeIndex + 1) % imageWrappers.length;
+      setActiveImage(nextIndex);
+    };
+
+    imageWrappers.forEach(function (wrapper) {
+      wrapper.addEventListener("click", function (event) {
+        event.preventDefault();
+        showNextImage();
+      });
+
+      wrapper.addEventListener("keydown", function (event) {
+        if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+          event.preventDefault();
+          showNextImage();
+        }
+      });
+    });
+
+    setActiveImage(activeIndex);
+  });
+
   // trigger popovers
   $('[data-toggle="popover"]').popover({
     trigger: "hover",


### PR DESCRIPTION
## Summary
- remove the profile photo toggle button markup while keeping the screen reader status text
- drop the sample front matter option and note that visitors can click the photo to cycle images
- clean up CSS/JS that supported the removed button while preserving image click/keyboard switching

## Testing
- `bundle exec jekyll build` *(fails: jekyll command not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce11ec76c8833094c73a6823d22c1d