### PR TITLE
Remove bold styling from first name in about layout

### DIFF
--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -5,7 +5,7 @@ layout: default
   <header class="post-header">
     <h1 class="post-title">
       {% if site.title == 'blank' %}
-        <span class="font-weight-bold">{{ site.first_name }}</span> {{ site.middle_name }}
+        {{ site.first_name }}{% if site.middle_name %} {{ site.middle_name }}{% endif %}
         {{ site.last_name }}
       {% else %}
         {{ site.title }}


### PR DESCRIPTION
## Summary
- render the first name without the `font-weight-bold` span when the about page header uses individual name parts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf440820f88330a7bed1bcd8529801