### PR TITLE
Highlight co-first authorship for Give Me FP32

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -4,13 +4,13 @@
 @misc{yuan2025fp32deathchallengessolutions,
   abbr = {NeurIPS},
   title = {Give Me FP32 or Give Me Death? Challenges and Solutions for Reproducible Reasoning},
-  author = {Yuan, Jiayi and Li, Hao and Ding, Xinheng and Xie, Wenya and Li, Yu-Jhe and Zhao, Wentian and Wan, Kun and Shi, Jing and Hu, Xia and Liu, Zirui},
+  author = {{Jiayi Yuan*} and {Hao Li*} and Ding, Xinheng and Xie, Wenya and Li, Yu-Jhe and Zhao, Wentian and Wan, Kun and Shi, Jing and Hu, Xia and Liu, Zirui},
   year = {2025},
   eprint = {2506.09501},
   archivePrefix = {arXiv},
   primaryClass = {cs.CL},
   url = {https://arxiv.org/abs/2506.09501},
-  note = {NeurIPS 2025 (Oral). Co-first author.},
+  note = {NeurIPS 2025 (Oral). Co-first authors marked with *.},
   selected = {true}
 }
 

--- a/_config.yml
+++ b/_config.yml
@@ -264,8 +264,8 @@ display_categories: ["external-services"] # these categories will be displayed o
 # -----------------------------------------------------------------------------
 
 scholar:
-  last_name: [Einstein]
-  first_name: [Albert, A.]
+  last_name: [Li]
+  first_name: [Hao, H.]
 
   style: apa
   locale: en


### PR DESCRIPTION
## Summary
- mark Jiayi Yuan and Hao Li as co-first authors with asterisks in the "Give Me FP32" bibliography entry
- configure the site to highlight Hao Li in publication listings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5fc8d5e7c83308d38ff799e13f45b