### PR TITLE
Remove unused navigation tabs

### DIFF
--- a/_pages/profiles.md
+++ b/_pages/profiles.md
@@ -3,8 +3,6 @@ layout: profiles
 permalink: /people/
 title: people
 description: members of the lab or group
-nav: true
-nav_order: 7
 
 profiles:
   # if you want to include more than one profile, just replicate the following block

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -3,8 +3,6 @@ layout: page
 title: projects
 permalink: /projects/
 description: A growing collection of your cool projects.
-nav: true
-nav_order: 3
 display_categories: [work, fun]
 horizontal: false
 ---

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -3,8 +3,6 @@ layout: page
 permalink: /repositories/
 title: repositories
 description: Edit the `_data/repositories.yml` and change the `github_users` and `github_repos` lists to include your own GitHub profile and repositories.
-nav: true
-nav_order: 4
 ---
 
 {% if site.data.repositories.github_users %}

--- a/_pages/teaching.md
+++ b/_pages/teaching.md
@@ -3,8 +3,6 @@ layout: page
 permalink: /teaching/
 title: teaching
 description: Materials for courses you taught. Replace this text with your description.
-nav: true
-nav_order: 6
 ---
 
 For now, this page is assumed to be a static description of your courses. You can convert it to a collection similar to `_projects/` so that you can have a dedicated page for each course.


### PR DESCRIPTION
## Summary
- remove the navigation flag from the Projects, Repositories, Teaching, and People pages so they no longer appear as top-level tabs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6130d68b8833094addff66566e7e7