### PR TITLE
Fix navbar name weight on publications page

### DIFF
--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -6,9 +6,7 @@
         <a class="navbar-brand title font-weight-lighter" href="{{ site.baseurl }}/">
           {% if site.title == 'blank' %}
             {% if site.first_name %}
-              <span class="font-weight-bold">
-                {{- site.first_name -}}
-              </span>
+              {{- site.first_name -}}
             {% endif %}
             {% if site.middle_name %}
               {{- site.middle_name -}}


### PR DESCRIPTION
## Summary
- remove the special bold styling around the first name in the navbar brand so the entire name renders with consistent weight

## Testing
- not run (bundle install failed: Bundler could not download gems due to HTTP 403)


------
https://chatgpt.com/codex/tasks/task_e_68d7036501348330a8fedb2834742119