### PR TITLE
Update NeurIPS Oral publication title to final published name

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -2,7 +2,7 @@
 ---
 
 @misc{yuan2025fp32deathchallengessolutions,
-  title = {Give Me FP32 or Give Me Death? Challenges and Solutions for Reproducible Reasoning},
+  title = {Understanding and Mitigating Numerical Sources of Nondeterminism in LLM Inference},
   author = {Jiayi Yuan* and Li*, Hao and Ding, Xinheng and Xie, Wenya and Li, Yu-Jhe and Zhao, Wentian and Wan, Kun and Shi, Jing and Hu, Xia and Liu, Zirui},
   year = {2025},
   abbr = {NeurIPS Oral},


### PR DESCRIPTION
### Motivation
- Replace the draft NeurIPS oral paper title with the final published title to keep the site's bibliography accurate: "Understanding and Mitigating Numerical Sources of Nondeterminism in LLM Inference".

### Description
- Updated the `title` field for the `@misc{yuan2025fp32deathchallengessolutions}` entry in `_bibliography/papers.bib` and committed the change with message `Update NeurIPS Oral publication title`.

### Testing
- Verified the change with `rg -n` to find the new title, inspected the diff with `git diff -- _bibliography/papers.bib`, and printed the file with `nl -ba`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeffe51cf08330a1fbd4ab7a0d4c88)